### PR TITLE
Remove songs that can't be embedded, added few more, issue fix for issue #19

### DIFF
--- a/src/components/FocusRoom.tsx
+++ b/src/components/FocusRoom.tsx
@@ -23,14 +23,44 @@ const curatedTracks = [
     artist: 'Lofi Girl',
   },
   {
-    id: 'DWcJFNfaw9c',
-    title: 'Deep Focus - Music For Coding, Programming, Working',
-    artist: 'Chill Music Lab',
-  },
-  {
     id: '2gliGzb2_1I',
     title: 'Calm Piano Music 24/7: Study Music, Focus, Think, Meditation, Relaxing Music',
     artist: 'Yellow Brick Cinema',
+  },
+  {
+    id: 'rYEDA3JcQqw',
+    title: 'Rain and Coffee Shop - Lofi Hip Hop Music',
+    artist: 'Lofi Hip Hop',
+  },
+  {
+    id: '36YnV9STBqc',
+    title: 'Deep Focus Music - Binaural Beats Concentration Music',
+    artist: 'Meditation Relax Music',
+  },
+  {
+    id: 'fEvM-OUbaKs',
+    title: 'Coffee House Jazz - Relaxing Instrumental Music',
+    artist: 'Cafe Music BGM channel',
+  },
+  {
+    id: '1fueZCTYkpA',
+    title: 'Relaxing Piano Music for Studying and Concentration',
+    artist: 'Yellow Brick Cinema',
+  },
+  {
+    id: 'WPni755-Krg',
+    title: 'Study Music - Improve Brain Power, Focus Music',
+    artist: 'YellowBrickCinema',
+  },
+  {
+    id: 'RgKAFK5djSk',
+    title: 'Peaceful Guitar Music for Studying',
+    artist: 'Soothing Relaxation',
+  },
+  {
+    id: 'CfPxlb8-ZQ0',
+    title: 'Zen Garden - Meditation and Study Music',
+    artist: 'Meditation Music Zone',
   },
 ];
 


### PR DESCRIPTION
FocusRoom Playlist Fix Summary

  Problem:

  - Original playlist had 4 songs, but the 3rd song (DWcJFNfaw9c) was
  broken and wouldn't play
  - User requested to expand to 10 total songs
  - Multiple replacement attempts had embedding restrictions

  Solution Process:

  1. Removed broken track: DWcJFNfaw9c - "Deep Focus - Music For Coding,
  Programming, Working"
  2. Added 7 new tracks to reach 10 total songs
  3. Fixed embedding issues: Replaced 9 problematic tracks through
  multiple iterations due to YouTube embedding restrictions

  Final Working Playlist (10 tracks):

  1. Lofi Hip Hop Radio - Lofi Girl ✅
  2. Synthwave Radio - Lofi Girl ✅
  3. Calm Piano Music 24/7 - Yellow Brick Cinema ✅
  4. Rain and Coffee Shop - Lofi Hip Hop ✅
  5. Deep Focus Music - Binaural Beats - Meditation Relax Music ✅
  6. Coffee House Jazz - Cafe Music BGM channel ✅
  7. Relaxing Piano Music for Studying - Yellow Brick Cinema ✅
  8. Study Music - Improve Brain Power - YellowBrickCinema ✅
  9. Peaceful Guitar Music for Studying - Soothing Relaxation ✅
  10. Zen Garden - Meditation and Study Music - Meditation Music Zone ✅

  Key Improvements:

  - ✅ Expanded from 4 to 10 songs for better variety
  - ✅ All tracks verified to work with YouTube embedding
  - ✅ Diverse music styles: Lofi, jazz, piano, binaural beats, guitar,
  ambient
  - ✅ Focus-optimized playlist perfect for Pomodoro sessions